### PR TITLE
Fix thread-safe logger

### DIFF
--- a/common/src/main/java/com/alibaba/datax/common/util/LimitLogger.java
+++ b/common/src/main/java/com/alibaba/datax/common/util/LimitLogger.java
@@ -2,8 +2,8 @@ package com.alibaba.datax.common.util;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author jitongchen
@@ -11,7 +11,8 @@ import java.util.Map;
  */
 public class LimitLogger {
 
-    private static Map<String, Long> lastPrintTime = new HashMap<>();
+    // use thread-safe map to avoid race conditions when logging from multiple threads
+    private static final Map<String, Long> lastPrintTime = new ConcurrentHashMap<>();
 
     public static void limit(String name, long limit, LoggerFunction function) {
         if (StringUtils.isBlank(name)) {
@@ -19,16 +20,16 @@ public class LimitLogger {
         }
         if (limit <= 0) {
             function.apply();
-        } else {
-            if (!lastPrintTime.containsKey(name)) {
-                lastPrintTime.put(name, System.currentTimeMillis());
-                function.apply();
-            } else {
-                if (System.currentTimeMillis() > lastPrintTime.get(name) + limit) {
-                    lastPrintTime.put(name, System.currentTimeMillis());
-                    function.apply();
-                }
-            }
+            return;
         }
+
+        long now = System.currentTimeMillis();
+        lastPrintTime.compute(name, (k, v) -> {
+            if (v == null || now - v > limit) {
+                function.apply();
+                return now;
+            }
+            return v;
+        });
     }
 }


### PR DESCRIPTION
## Summary
- use a ConcurrentHashMap in `LimitLogger`
- update logging logic to atomically update the timestamp

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683feb9763b88324a8c2e8373006b1f0